### PR TITLE
From geography to geometry + added gist index

### DIFF
--- a/lib/shapes.js
+++ b/lib/shapes.js
@@ -6,7 +6,7 @@ CREATE TABLE ${opt.schema}.shapes (
 	id SERIAL PRIMARY KEY,
 	shape_id TEXT,
 	shape_pt_sequence INT,
-	shape_pt_loc geography(POINT),
+	shape_pt_loc geometry(POINT),
 	shape_dist_traveled REAL
 );
 

--- a/lib/stops.js
+++ b/lib/stops.js
@@ -36,7 +36,7 @@ CREATE TABLE ${opt.schema}.stops (
 	-- todo: Required for locations which are stops (location_type=0), stations (location_type=1) or entrances/exits (location_type=2). Optional for locations which are generic nodes (location_type=3) or boarding areas (location_type=4).
 	stop_name TEXT,
 	stop_desc TEXT,
-	stop_loc geography(POINT), -- stop_lat/stop_lon
+	stop_loc geometry(POINT), -- stop_lat/stop_lon
 	zone_id TEXT,
 	stop_url TEXT,
 	location_type ${opt.schema}.location_type_val,
@@ -111,6 +111,7 @@ ADD CONSTRAINT stops_parent_station_fkey
 FOREIGN KEY (parent_station) REFERENCES ${opt.schema}.stops;
 
 CREATE INDEX ON ${opt.schema}.stops (parent_station);
+CREATE INDEX ON ${opt.schema}.stops USING GIST(stop_loc);
 `
 
 module.exports = {


### PR DESCRIPTION
The geometry columns were using the type geography in **stops** and **shapes** table. From my point of view, it should use the geometry type as spatial queries involving the geography type are usually very slow. Furthermore, I added a spatial index for the stops table. I was avoiding so far setting a coordinate reference system in the geometry field as this might be too restricted but it could make sense to have more validation. Furthermore, it could be advisable to also add a spatial index on the **shapes** table. 

